### PR TITLE
Make sure Main window exists during startup

### DIFF
--- a/hyperion/manager.py
+++ b/hyperion/manager.py
@@ -750,7 +750,9 @@ class AbstractController(object):
             State of the component
         """
 
-        if self.mon_thread.is_component_monitored(comp['id']):
+        if self.mon_thread.is_component_monitored(comp["id"]):
+            if broadcast:
+                self.broadcast_event(events.CheckEvent(comp["id"], config.CheckState.RUNNING))
             return config.CheckState.RUNNING
 
         try:

--- a/hyperion/manager.py
+++ b/hyperion/manager.py
@@ -1377,6 +1377,13 @@ class ControlCenter(AbstractController):
                 "to create a new one"
             )
 
+            if self.session:
+                window = self._find_window('Main')
+                if not window:
+                    self.logger.debug("Session has no 'Main' window, Maybe session is in use somewhere.")
+                    self.session.new_window('Main')
+                session_ready = True    
+
         if not session_ready:
             self.logger.info(
                 f'starting new session by name "{self.session_name}" on server'


### PR DESCRIPTION
Possible to crash before Main window is created so we make sure Main gets created to not get stuck later

 e.g. by using python2.7 with libtmux 'latest' we can create a session but no window